### PR TITLE
Remove language codes whose po file doesn't exist

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -2,6 +2,4 @@ de
 fr
 lt
 pl
-pt_BR
-pt
 ru_RU


### PR DESCRIPTION
`pt_BR.po` and `pt.po` does not exist, so we can remove their language codes safely.
